### PR TITLE
Return to train mode after validation

### DIFF
--- a/torchfcn/trainer.py
+++ b/torchfcn/trainer.py
@@ -154,6 +154,8 @@ class Trainer(object):
             shutil.copy(osp.join(self.out, 'checkpoint.pth.tar'),
                         osp.join(self.out, 'model_best.pth.tar'))
 
+    self.model.train()
+
     def train_epoch(self):
         self.model.train()
 


### PR DESCRIPTION
Validation can occur before end of epoch, which sets model mode to eval.
Training will have no effect until end of the epoch.