### PR TITLE
Update for PyTorch >= 0.3

### DIFF
--- a/torchfcn/trainer.py
+++ b/torchfcn/trainer.py
@@ -1,4 +1,5 @@
 import datetime
+from distutils.version import LooseVersion
 import math
 import os
 import os.path as osp
@@ -20,7 +21,12 @@ def cross_entropy2d(input, target, weight=None, size_average=True):
     # input: (n, c, h, w), target: (n, h, w)
     n, c, h, w = input.size()
     # log_p: (n, c, h, w)
-    log_p = F.log_softmax(input, dim=1)
+    if LooseVersion(torch.__version__) < LooseVersion('0.3'):
+        # ==0.2.X
+        log_p = F.log_softmax(input)
+    else:
+        # >=0.3
+        log_p = F.log_softmax(input, dim=1)
     # log_p: (n*h*w, c)
     log_p = log_p.transpose(1, 2).transpose(2, 3).contiguous()
     log_p = log_p[target.view(n, h, w, 1).repeat(1, 1, 1, c) >= 0]

--- a/torchfcn/trainer.py
+++ b/torchfcn/trainer.py
@@ -20,9 +20,9 @@ def cross_entropy2d(input, target, weight=None, size_average=True):
     # input: (n, c, h, w), target: (n, h, w)
     n, c, h, w = input.size()
     # log_p: (n, c, h, w)
-    log_p = F.log_softmax(input)
+    log_p = F.log_softmax(input, dim=1)
     # log_p: (n*h*w, c)
-    log_p = log_p.transpose(1, 2).transpose(2, 3).contiguous().view(-1, c)
+    log_p = log_p.transpose(1, 2).transpose(2, 3).contiguous()
     log_p = log_p[target.view(n, h, w, 1).repeat(1, 1, 1, c) >= 0]
     log_p = log_p.view(-1, c)
     # target: (n*h*w,)


### PR DESCRIPTION
**Line 23** As of PyTorch >= 0.3 log_softmax raises `UserWarning: Implicit dimension choice for log_softmax has been deprecated. Change the call to include dim=X as an argument.`

**Line 25** The mask and index tensors must have the same dimensions. In PyTorch 0.3, this raises a warning `UserWarning: self and mask not broadcastable, but have the same number of elements.  Falling back to deprecated pointwise behavior.` and then fails with the following traceback
```
Traceback (most recent call last):
  File "examples/voc/train_fcn32s.py", line 164, in <module>
    main()
  File "examples/voc/train_fcn32s.py", line 160, in main
    trainer.train()
  File "/zfsauton/home/mbarnes1/deep_spectral_clustering/torchfcn/trainer.py", line 221, in train
    self.train_epoch()
  File "/zfsauton/home/mbarnes1/deep_spectral_clustering/torchfcn/trainer.py", line 191, in train_epoch
    loss.backward()
  File "/zfsauton/home/mbarnes1/miniconda2/envs/torch/lib/python2.7/site-packages/torch/autograd/variable.py", line 167, in backward
    torch.autograd.backward(self, gradient, retain_graph, create_graph, retain_variables)
  File "/zfsauton/home/mbarnes1/miniconda2/envs/torch/lib/python2.7/site-packages/torch/autograd/__init__.py", line 99, in backward
    variables, grad_variables, retain_graph)
  File "/zfsauton/home/mbarnes1/miniconda2/envs/torch/lib/python2.7/site-packages/torch/autograd/function.py", line 91, in apply
    return self._forward_cls.backward(self, *args)
  File "/zfsauton/home/mbarnes1/miniconda2/envs/torch/lib/python2.7/site-packages/torch/autograd/_functions/tensor.py", line 481, in backward
    grad_tensor = grad_tensor.masked_scatter(mask, grad_output)
  File "/zfsauton/home/mbarnes1/miniconda2/envs/torch/lib/python2.7/site-packages/torch/autograd/variable.py", line 427, in masked_scatter
    return self.clone().masked_scatter_(mask, variable)
RuntimeError: invalid argument 1: the number of sizes provided must be greater or equal to the number of dimensions in the tensor at /pytorch/torch/lib/THC/generic/THCTensor.c:309
```

PyTorch 0.4 provides a better traceback: `RuntimeError: The shape of the mask [1, 366, 500, 21] at index 0 does not match the shape of the indexed tensor [183000, 21] at index 0`
  