### PR TITLE
Make submodule (github2pypi) also cloneable when cloning pytorch-fcn.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ PyTorch implementation of [Fully Convolutional Networks](https://github.com/shel
 ## Installation
 
 ```bash
-git clone https://github.com/wkentaro/pytorch-fcn.git
+git clone https://github.com/wkentaro/pytorch-fcn.git --recursive
 cd pytorch-fcn
 pip install .
 


### PR DESCRIPTION
```bash
git clone https://github.com/wkentaro/pytorch-fcn.git
```
Above command cannot clone submodules, so github2pypi is empty after cloning this repository.
So ` pip install . `  causes "no attribute error".