### PR TITLE
scipy.misc.imsave is removed in 1.2.0. Use imageio.imwrite instead.

### DIFF
--- a/torchfcn/trainer.py
+++ b/torchfcn/trainer.py
@@ -6,9 +6,9 @@ import os.path as osp
 import shutil
 
 import fcn
+import imageio
 import numpy as np
 import pytz
-import scipy.misc
 import torch
 from torch.autograd import Variable
 import torch.nn.functional as F
@@ -134,7 +134,7 @@ class Trainer(object):
         if not osp.exists(out):
             os.makedirs(out)
         out_file = osp.join(out, 'iter%012d.jpg' % self.iteration)
-        scipy.misc.imsave(out_file, fcn.utils.get_tile_image(visualizations))
+        imageio.imwrite(out_file, fcn.utils.get_tile_image(visualizations))
 
         val_loss /= len(self.val_loader)
 


### PR DESCRIPTION
`scipy.misc.imsave` is **removed in v1.2.0**. The Letest version of scipy is 1.3.0, so we get the `AttributeError` when training, for example `fcn8s_atonce.py`.
(https://docs.scipy.org/doc/scipy-1.1.0/reference/generated/scipy.misc.imsave.html)

Above document recommend using `imageio.imwrite` instead.

`imageio` is already installed. (fcn -> scikit-image -> imageio)